### PR TITLE
A crash in status window (with a patch)

### DIFF
--- a/spugtex.pl
+++ b/spugtex.pl
@@ -185,6 +185,12 @@ sub cmd_math {
 		return;
 	}
 
+	if (!$witem || 
+            !($witem->{type} eq "CHANNEL" || $witem->{type} eq "QUERY")) {
+		Irssi:print("Not on active channel or query, try mathp instead");
+		return;
+	}
+
 	if (!$data) {
 		return;
 	}


### PR DESCRIPTION
Previously when /math was issued on status window the script crashed
with message:
  Can't call method "command" on an undefined value at $HOME/.irssi/scripts/spugtex.pl line 193.

I added checks to prevent this from happening and now it just prints
  Not on a channel or query, try mathp instead

I guess that's a bit better than just crashing. Another way to handle
this would be to call Irssi:active_window->print like /mathp does or
call /mathp's function to show preview.

I can make a new pull request to do this some other way if that's better. I just didn't quite know which would be better. 